### PR TITLE
replace CTA button with discord invite

### DIFF
--- a/23/index.html
+++ b/23/index.html
@@ -72,7 +72,7 @@
                     </div>
                 </div>
                 <div class="center">
-                    <a href="https://blanketcon.modfest.net/signup"><button>SIGN UP</button></a>
+                    <a href="https://discord.modfest.net" target="_blank"><button>JOIN OUR DISCORD</button></a>
                 </div>
                 <p>
                     BlanketCon 23: cyber/NOVA is an in-game Minecraft modding convention hosted by ModFest and CHS, and open to all mod enthusiasts and developers!

--- a/23/index.html
+++ b/23/index.html
@@ -120,6 +120,7 @@
                 <ul class="center no-bullets">
                     <li><a href="https://quiltmc.org/">The Quilt Project</a></li>
                 </ul-->
+                <p>Powered by <a href="https://modfest.net">Modfest</a></p>
             </div>
         </div>
     </main>


### PR DESCRIPTION
- switch the main call-to-action button from signup to discord invite
- add 'powered by modfest' line in footer